### PR TITLE
Refactoring / composite pattern - part 1

### DIFF
--- a/abi/codec_test.go
+++ b/abi/codec_test.go
@@ -7,51 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCodec(t *testing.T) {
-	t.Run("should create new codec", func(t *testing.T) {
-		codec, err := newCodec(argsNewCodec{
-			pubKeyLength: 32,
-		})
-
-		require.NoError(t, err)
-		require.NotNil(t, codec)
-	})
-
-	t.Run("should err on creating new codec when public key length is bad", func(t *testing.T) {
-		_, err := newCodec(argsNewCodec{
-			pubKeyLength: 0,
-		})
-
-		require.ErrorContains(t, err, "bad public key length")
-	})
-
-	t.Run("should err when encoding or decoding an unknown type", func(t *testing.T) {
-		codec, _ := newCodec(argsNewCodec{
-			pubKeyLength: 32,
-		})
-
-		type dummyType struct {
-			foobar string
-		}
-
-		encoded, err := codec.EncodeNested(&dummyType{foobar: "hello"})
-		require.ErrorContains(t, err, "unsupported type for nested encoding: *abi.dummy")
-		require.Nil(t, encoded)
-
-		encoded, err = codec.EncodeTopLevel(&dummyType{foobar: "hello"})
-		require.ErrorContains(t, err, "unsupported type for top-level encoding: *abi.dummy")
-		require.Nil(t, encoded)
-
-		err = codec.DecodeNested([]byte{0x00}, &dummyType{foobar: "hello"})
-		require.ErrorContains(t, err, "unsupported type for nested decoding: *abi.dummy")
-
-		err = codec.DecodeTopLevel([]byte{0x00}, &dummyType{foobar: "hello"})
-		require.ErrorContains(t, err, "unsupported type for top-level decoding: *abi.dummy")
-	})
-}
-
 // testEncodeNested is a helper function to test nested encoding.
-func testEncodeNested(t *testing.T, codec *codec, value any, expected string) {
+func testEncodeNested(t *testing.T, codec *codec, value SingleValue, expected string) {
 	encoded, err := codec.EncodeNested(value)
 
 	require.NoError(t, err)
@@ -59,7 +16,7 @@ func testEncodeNested(t *testing.T, codec *codec, value any, expected string) {
 }
 
 // testEncodeTopLevel is a helper function to test top-level encoding.
-func testEncodeTopLevel(t *testing.T, codec *codec, value any, expected string) {
+func testEncodeTopLevel(t *testing.T, codec *codec, value SingleValue, expected string) {
 	encoded, err := codec.EncodeTopLevel(value)
 
 	require.NoError(t, err)
@@ -67,7 +24,7 @@ func testEncodeTopLevel(t *testing.T, codec *codec, value any, expected string) 
 }
 
 // testDecodeNested is a helper function to test nested decoding.
-func testDecodeNested(t *testing.T, codec *codec, encodedData string, destination any, expected any) {
+func testDecodeNested(t *testing.T, codec *codec, encodedData string, destination SingleValue, expected SingleValue) {
 	data, _ := hex.DecodeString(encodedData)
 	err := codec.DecodeNested(data, destination)
 
@@ -76,7 +33,7 @@ func testDecodeNested(t *testing.T, codec *codec, encodedData string, destinatio
 }
 
 // testDecodeNestedWithError is a helper function to test nested decoding.
-func testDecodeNestedWithError(t *testing.T, codec *codec, encodedData string, destination any, expectedError string) {
+func testDecodeNestedWithError(t *testing.T, codec *codec, encodedData string, destination SingleValue, expectedError string) {
 	data, _ := hex.DecodeString(encodedData)
 	err := codec.DecodeNested(data, destination)
 
@@ -84,7 +41,7 @@ func testDecodeNestedWithError(t *testing.T, codec *codec, encodedData string, d
 }
 
 // testDecodeTopLevel is a helper function to test top-level decoding.
-func testDecodeTopLevel(t *testing.T, codec *codec, encodedData string, destination any, expected any) {
+func testDecodeTopLevel(t *testing.T, codec *codec, encodedData string, destination SingleValue, expected SingleValue) {
 	data, _ := hex.DecodeString(encodedData)
 	err := codec.DecodeTopLevel(data, destination)
 
@@ -93,7 +50,7 @@ func testDecodeTopLevel(t *testing.T, codec *codec, encodedData string, destinat
 }
 
 // testDecodeTopLevelWithError is a helper function to test top-level decoding.
-func testDecodeTopLevelWithError(t *testing.T, codec *codec, encodedData string, destination any, expectedError string) {
+func testDecodeTopLevelWithError(t *testing.T, codec *codec, encodedData string, destination SingleValue, expectedError string) {
 	data, _ := hex.DecodeString(encodedData)
 	err := codec.DecodeTopLevel(data, destination)
 

--- a/abi/constants.go
+++ b/abi/constants.go
@@ -4,3 +4,4 @@ const trueAsByte = uint8(1)
 const falseAsByte = uint8(0)
 const optionMarkerForAbsentValue = uint8(0)
 const optionMarkerForPresentValue = uint8(1)
+const pubKeyLength = 32

--- a/abi/interface.go
+++ b/abi/interface.go
@@ -2,8 +2,11 @@ package abi
 
 import "io"
 
-// generalCodec is an internal interface that allows "leaf" codecs to rely on the general "composite" codec, if needed.
-type generalCodec interface {
-	doEncodeNested(writer io.Writer, value any) error
-	doDecodeNested(reader io.Reader, value any) error
+// SingleValue is the interface to be implemented by all "single value" types, with respect to:
+// https://docs.multiversx.com/developers/data/serialization-overview
+type SingleValue interface {
+	EncodeNested(writer io.Writer) error
+	EncodeTopLevel(writer io.Writer) error
+	DecodeNested(reader io.Reader) error
+	DecodeTopLevel(data []byte) error
 }

--- a/abi/serializer.go
+++ b/abi/serializer.go
@@ -14,7 +14,6 @@ type serializer struct {
 // ArgsNewSerializer defines the arguments needed for a new serializer
 type ArgsNewSerializer struct {
 	PartsSeparator string
-	PubKeyLength   int
 }
 
 // NewSerializer creates a new serializer.

--- a/abi/serializer.go
+++ b/abi/serializer.go
@@ -25,12 +25,7 @@ func NewSerializer(args ArgsNewSerializer) (*serializer, error) {
 		return nil, errors.New("cannot create serializer: parts separator must not be empty")
 	}
 
-	codec, err := newCodec(argsNewCodec{
-		pubKeyLength: args.PubKeyLength,
-	})
-	if err != nil {
-		return nil, err
-	}
+	codec := &codec{}
 
 	return &serializer{
 		codec:          codec,
@@ -85,9 +80,11 @@ func (s *serializer) doSerialize(partsHolder *partsHolder, inputValues []any) er
 			}
 
 			err = s.serializeInputVariadicValues(partsHolder, value)
-		default:
+		case SingleValue:
 			partsHolder.appendEmptyPart()
-			err = s.serializeDirectlyEncodableValue(partsHolder, value)
+			err = s.serializeSingleValue(partsHolder, value)
+		default:
+			return fmt.Errorf("unsupported type for serialization: %T", value)
 		}
 
 		if err != nil {
@@ -144,9 +141,10 @@ func (s *serializer) doDeserialize(partsHolder *partsHolder, outputValues []any)
 				return errors.New("variadic values must be last among output values")
 			}
 
-			err = s.deserializeOutputVariadicValues(partsHolder, value)
+		case SingleValue:
+			err = s.deserializeSingleValue(partsHolder, value)
 		default:
-			err = s.deserializeDirectlyEncodableValue(partsHolder, value)
+			return fmt.Errorf("unsupported type for deserialization: %T", value)
 		}
 
 		if err != nil {
@@ -187,7 +185,7 @@ func (s *serializer) serializeInputVariadicValues(partsHolder *partsHolder, valu
 	return nil
 }
 
-func (s *serializer) serializeDirectlyEncodableValue(partsHolder *partsHolder, value any) error {
+func (s *serializer) serializeSingleValue(partsHolder *partsHolder, value SingleValue) error {
 	data, err := s.codec.EncodeTopLevel(value)
 	if err != nil {
 		return err
@@ -240,7 +238,7 @@ func (s *serializer) deserializeOutputVariadicValues(partsHolder *partsHolder, v
 	return nil
 }
 
-func (s *serializer) deserializeDirectlyEncodableValue(partsHolder *partsHolder, value any) error {
+func (s *serializer) deserializeSingleValue(partsHolder *partsHolder, value SingleValue) error {
 	part, err := partsHolder.readWholeFocusedPart()
 	if err != nil {
 		return err


### PR DESCRIPTION
This is a PR from a series of many.

Here, we simplify the implementation of `codec`. No more switch statements. All `SingleValue` objects are responsible with encoding / decoding themselves.

See: https://github.com/multiversx/mx-sdk-abi-go/issues/5.