### PR TITLE
Refactoring / composite pattern - refactor codecFor* into *Value (for some codecs)

### DIFF
--- a/abi/addressValue.go
+++ b/abi/addressValue.go
@@ -5,12 +5,14 @@ import (
 	"io"
 )
 
-type codecForAddress struct {
-	pubKeyLength int
+// AddressValue is a wrapper for an address
+type AddressValue struct {
+	Value []byte
 }
 
-func (c *codecForAddress) encodeNested(writer io.Writer, value AddressValue) error {
-	err := c.checkPubKeyLength(value.Value)
+// EncodeNested encodes the value in the nested form
+func (value *AddressValue) EncodeNested(writer io.Writer) error {
+	err := value.checkPubKeyLength(value.Value)
 	if err != nil {
 		return err
 	}
@@ -19,12 +21,14 @@ func (c *codecForAddress) encodeNested(writer io.Writer, value AddressValue) err
 	return err
 }
 
-func (c *codecForAddress) encodeTopLevel(writer io.Writer, value AddressValue) error {
-	return c.encodeNested(writer, value)
+// EncodeTopLevel encodes the value in the top-level form
+func (value *AddressValue) EncodeTopLevel(writer io.Writer) error {
+	return value.EncodeNested(writer)
 }
 
-func (c *codecForAddress) decodeNested(reader io.Reader, value *AddressValue) error {
-	data, err := readBytesExactly(reader, c.pubKeyLength)
+// DecodeNested decodes the value from the nested form
+func (value *AddressValue) DecodeNested(reader io.Reader) error {
+	data, err := readBytesExactly(reader, pubKeyLength)
 	if err != nil {
 		return err
 	}
@@ -33,8 +37,9 @@ func (c *codecForAddress) decodeNested(reader io.Reader, value *AddressValue) er
 	return nil
 }
 
-func (c *codecForAddress) decodeTopLevel(data []byte, value *AddressValue) error {
-	err := c.checkPubKeyLength(data)
+// DecodeTopLevel decodes the value from the top-level form
+func (value *AddressValue) DecodeTopLevel(data []byte) error {
+	err := value.checkPubKeyLength(data)
 	if err != nil {
 		return err
 	}
@@ -43,8 +48,8 @@ func (c *codecForAddress) decodeTopLevel(data []byte, value *AddressValue) error
 	return nil
 }
 
-func (c *codecForAddress) checkPubKeyLength(pubkey []byte) error {
-	if len(pubkey) != c.pubKeyLength {
+func (value *AddressValue) checkPubKeyLength(pubkey []byte) error {
+	if len(pubkey) != pubKeyLength {
 		return fmt.Errorf("public key (address) has invalid length: %d", len(pubkey))
 	}
 

--- a/abi/addressValue_test.go
+++ b/abi/addressValue_test.go
@@ -7,10 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCodecForAddress(t *testing.T) {
-	codec, _ := newCodec(argsNewCodec{
-		pubKeyLength: 32,
-	})
+func TestAddressValue(t *testing.T) {
+	codec := &codec{}
 
 	alicePubKeyHex := "0139472eff6886771a982f3083da5d421f24c29181e63888228dc81ca60d69e1"
 	alicePubKey, _ := hex.DecodeString(alicePubKeyHex)
@@ -19,20 +17,20 @@ func TestCodecForAddress(t *testing.T) {
 	shortPubKey, _ := hex.DecodeString(shortPubKeyHex)
 
 	t.Run("should encode nested", func(t *testing.T) {
-		testEncodeNested(t, codec, AddressValue{Value: alicePubKey}, alicePubKeyHex)
+		testEncodeNested(t, codec, &AddressValue{Value: alicePubKey}, alicePubKeyHex)
 	})
 
 	t.Run("should err on encode nested (bad public key length)", func(t *testing.T) {
-		_, err := codec.EncodeNested(AddressValue{Value: shortPubKey})
+		_, err := codec.EncodeNested(&AddressValue{Value: shortPubKey})
 		require.ErrorContains(t, err, "public key (address) has invalid length")
 	})
 
 	t.Run("should encode top-level", func(t *testing.T) {
-		testEncodeTopLevel(t, codec, AddressValue{Value: alicePubKey}, alicePubKeyHex)
+		testEncodeTopLevel(t, codec, &AddressValue{Value: alicePubKey}, alicePubKeyHex)
 	})
 
 	t.Run("should err on encode top-level (bad public key length)", func(t *testing.T) {
-		_, err := codec.EncodeTopLevel(AddressValue{Value: shortPubKey})
+		_, err := codec.EncodeTopLevel(&AddressValue{Value: shortPubKey})
 		require.ErrorContains(t, err, "public key (address) has invalid length")
 	})
 

--- a/abi/boolValue.go
+++ b/abi/boolValue.go
@@ -5,10 +5,13 @@ import (
 	"io"
 )
 
-type codecForBool struct {
+// BoolValue is a wrapper for a boolean
+type BoolValue struct {
+	Value bool
 }
 
-func (c *codecForBool) encodeNested(writer io.Writer, value BoolValue) error {
+// EncodeNested encodes the value in the nested form
+func (value *BoolValue) EncodeNested(writer io.Writer) error {
 	if value.Value {
 		_, err := writer.Write([]byte{trueAsByte})
 		return err
@@ -18,7 +21,8 @@ func (c *codecForBool) encodeNested(writer io.Writer, value BoolValue) error {
 	return err
 }
 
-func (c *codecForBool) encodeTopLevel(writer io.Writer, value BoolValue) error {
+// EncodeTopLevel encodes the value in the top-level form
+func (value *BoolValue) EncodeTopLevel(writer io.Writer) error {
 	if !value.Value {
 		// For "false", write nothing.
 		return nil
@@ -28,13 +32,14 @@ func (c *codecForBool) encodeTopLevel(writer io.Writer, value BoolValue) error {
 	return err
 }
 
-func (c *codecForBool) decodeNested(reader io.Reader, value *BoolValue) error {
+// DecodeNested decodes the value from the nested form
+func (value *BoolValue) DecodeNested(reader io.Reader) error {
 	data, err := readBytesExactly(reader, 1)
 	if err != nil {
 		return err
 	}
 
-	value.Value, err = c.byteToBool(data[0])
+	value.Value, err = value.byteToBool(data[0])
 	if err != nil {
 		return err
 	}
@@ -42,14 +47,15 @@ func (c *codecForBool) decodeNested(reader io.Reader, value *BoolValue) error {
 	return nil
 }
 
-func (c *codecForBool) decodeTopLevel(data []byte, value *BoolValue) error {
+// DecodeTopLevel decodes the value from the top-level form
+func (value *BoolValue) DecodeTopLevel(data []byte) error {
 	if len(data) == 0 {
 		value.Value = false
 		return nil
 	}
 
 	if len(data) == 1 {
-		boolValue, err := c.byteToBool(data[0])
+		boolValue, err := value.byteToBool(data[0])
 		if err != nil {
 			return err
 		}
@@ -61,7 +67,7 @@ func (c *codecForBool) decodeTopLevel(data []byte, value *BoolValue) error {
 	return fmt.Errorf("unexpected boolean value: %v", data)
 }
 
-func (c *codecForBool) byteToBool(data uint8) (bool, error) {
+func (value *BoolValue) byteToBool(data uint8) (bool, error) {
 	switch data {
 	case trueAsByte:
 		return true, nil

--- a/abi/boolValue_test.go
+++ b/abi/boolValue_test.go
@@ -4,19 +4,17 @@ import (
 	"testing"
 )
 
-func TestCodecForBool(t *testing.T) {
-	codec, _ := newCodec(argsNewCodec{
-		pubKeyLength: 32,
-	})
+func TestBoolValue(t *testing.T) {
+	codec := &codec{}
 
 	t.Run("should encode nested", func(t *testing.T) {
-		testEncodeNested(t, codec, BoolValue{Value: false}, "00")
-		testEncodeNested(t, codec, BoolValue{Value: true}, "01")
+		testEncodeNested(t, codec, &BoolValue{Value: false}, "00")
+		testEncodeNested(t, codec, &BoolValue{Value: true}, "01")
 	})
 
 	t.Run("should encode top-level", func(t *testing.T) {
-		testEncodeTopLevel(t, codec, BoolValue{Value: false}, "")
-		testEncodeTopLevel(t, codec, BoolValue{Value: true}, "01")
+		testEncodeTopLevel(t, codec, &BoolValue{Value: false}, "")
+		testEncodeTopLevel(t, codec, &BoolValue{Value: true}, "01")
 	})
 
 	t.Run("should decode nested", func(t *testing.T) {

--- a/abi/bytesValue.go
+++ b/abi/bytesValue.go
@@ -4,10 +4,13 @@ import (
 	"io"
 )
 
-type codecForBytes struct {
+// BytesValue is a wrapper for a byte slice
+type BytesValue struct {
+	Value []byte
 }
 
-func (c *codecForBytes) encodeNested(writer io.Writer, value BytesValue) error {
+// EncodeNested encodes the value in the nested form
+func (value *BytesValue) EncodeNested(writer io.Writer) error {
 	err := encodeLength(writer, uint32(len(value.Value)))
 	if err != nil {
 		return err
@@ -17,12 +20,14 @@ func (c *codecForBytes) encodeNested(writer io.Writer, value BytesValue) error {
 	return err
 }
 
-func (c *codecForBytes) encodeTopLevel(writer io.Writer, value BytesValue) error {
+// EncodeTopLevel encodes the value in the top-level form
+func (value *BytesValue) EncodeTopLevel(writer io.Writer) error {
 	_, err := writer.Write(value.Value)
 	return err
 }
 
-func (c *codecForBytes) decodeNested(reader io.Reader, value *BytesValue) error {
+// DecodeNested decodes the value from the nested form
+func (value *BytesValue) DecodeNested(reader io.Reader) error {
 	length, err := decodeLength(reader)
 	if err != nil {
 		return err
@@ -37,7 +42,8 @@ func (c *codecForBytes) decodeNested(reader io.Reader, value *BytesValue) error 
 	return nil
 }
 
-func (c *codecForBytes) decodeTopLevel(data []byte, value *BytesValue) error {
+// DecodeTopLevel decodes the value from the top-level form
+func (value *BytesValue) DecodeTopLevel(data []byte) error {
 	value.Value = data
 	return nil
 }

--- a/abi/bytesValue_test.go
+++ b/abi/bytesValue_test.go
@@ -4,19 +4,17 @@ import (
 	"testing"
 )
 
-func TestCodecForBytes(t *testing.T) {
-	codec, _ := newCodec(argsNewCodec{
-		pubKeyLength: 32,
-	})
+func TestBytesValue(t *testing.T) {
+	codec := &codec{}
 
 	t.Run("should encode nested", func(t *testing.T) {
-		testEncodeNested(t, codec, BytesValue{Value: []byte{}}, "00000000")
-		testEncodeNested(t, codec, BytesValue{Value: []byte{'a', 'b', 'c'}}, "00000003616263")
+		testEncodeNested(t, codec, &BytesValue{Value: []byte{}}, "00000000")
+		testEncodeNested(t, codec, &BytesValue{Value: []byte{'a', 'b', 'c'}}, "00000003616263")
 	})
 
 	t.Run("should encode top-level", func(t *testing.T) {
-		testEncodeTopLevel(t, codec, BytesValue{Value: []byte{}}, "")
-		testEncodeTopLevel(t, codec, BytesValue{Value: []byte{'a', 'b', 'c'}}, "616263")
+		testEncodeTopLevel(t, codec, &BytesValue{Value: []byte{}}, "")
+		testEncodeTopLevel(t, codec, &BytesValue{Value: []byte{'a', 'b', 'c'}}, "616263")
 	})
 
 	t.Run("should decode nested", func(t *testing.T) {

--- a/abi/stringValue.go
+++ b/abi/stringValue.go
@@ -4,10 +4,13 @@ import (
 	"io"
 )
 
-type codecForString struct {
+// StringValue is a wrapper for a string
+type StringValue struct {
+	Value string
 }
 
-func (c *codecForString) encodeNested(writer io.Writer, value StringValue) error {
+// EncodeNested encodes the value in the nested form
+func (value *StringValue) EncodeNested(writer io.Writer) error {
 	data := []byte(value.Value)
 	err := encodeLength(writer, uint32(len(data)))
 	if err != nil {
@@ -18,12 +21,14 @@ func (c *codecForString) encodeNested(writer io.Writer, value StringValue) error
 	return err
 }
 
-func (c *codecForString) encodeTopLevel(writer io.Writer, value StringValue) error {
+// EncodeTopLevel encodes the value in the top-level form
+func (value *StringValue) EncodeTopLevel(writer io.Writer) error {
 	_, err := writer.Write([]byte(value.Value))
 	return err
 }
 
-func (c *codecForString) decodeNested(reader io.Reader, value *StringValue) error {
+// DecodeNested decodes the value from the nested form
+func (value *StringValue) DecodeNested(reader io.Reader) error {
 	length, err := decodeLength(reader)
 	if err != nil {
 		return err
@@ -38,7 +43,8 @@ func (c *codecForString) decodeNested(reader io.Reader, value *StringValue) erro
 	return nil
 }
 
-func (c *codecForString) decodeTopLevel(data []byte, value *StringValue) error {
+// DecodeTopLevel decodes the value from the top-level form
+func (value *StringValue) DecodeTopLevel(data []byte) error {
 	value.Value = string(data)
 	return nil
 }

--- a/abi/stringValue_test.go
+++ b/abi/stringValue_test.go
@@ -4,19 +4,17 @@ import (
 	"testing"
 )
 
-func TestCodecForString(t *testing.T) {
-	codec, _ := newCodec(argsNewCodec{
-		pubKeyLength: 32,
-	})
+func TestStringValue(t *testing.T) {
+	codec := &codec{}
 
 	t.Run("should encode nested", func(t *testing.T) {
-		testEncodeNested(t, codec, StringValue{Value: ""}, "00000000")
-		testEncodeNested(t, codec, StringValue{Value: "abc"}, "00000003616263")
+		testEncodeNested(t, codec, &StringValue{Value: ""}, "00000000")
+		testEncodeNested(t, codec, &StringValue{Value: "abc"}, "00000003616263")
 	})
 
 	t.Run("should encode top-level", func(t *testing.T) {
-		testEncodeTopLevel(t, codec, StringValue{Value: ""}, "")
-		testEncodeTopLevel(t, codec, StringValue{Value: "abc"}, "616263")
+		testEncodeTopLevel(t, codec, &StringValue{Value: ""}, "")
+		testEncodeTopLevel(t, codec, &StringValue{Value: "abc"}, "616263")
 	})
 
 	t.Run("should decode nested", func(t *testing.T) {

--- a/abi/structValue.go
+++ b/abi/structValue.go
@@ -6,13 +6,15 @@ import (
 	"io"
 )
 
-type codeForStruct struct {
-	generalCodec generalCodec
+// StructValue is a struct (collection of fields)
+type StructValue struct {
+	Fields []Field
 }
 
-func (c *codeForStruct) encodeNested(writer io.Writer, value StructValue) error {
+// EncodeNested encodes the value in the nested form
+func (value *StructValue) EncodeNested(writer io.Writer) error {
 	for _, field := range value.Fields {
-		err := c.generalCodec.doEncodeNested(writer, field.Value)
+		err := field.Value.EncodeNested(writer)
 		if err != nil {
 			return fmt.Errorf("cannot encode field '%s' of struct, because of: %w", field.Name, err)
 		}
@@ -21,13 +23,15 @@ func (c *codeForStruct) encodeNested(writer io.Writer, value StructValue) error 
 	return nil
 }
 
-func (c *codeForStruct) encodeTopLevel(writer io.Writer, value StructValue) error {
-	return c.encodeNested(writer, value)
+// EncodeTopLevel encodes the value in the top-level form
+func (value *StructValue) EncodeTopLevel(writer io.Writer) error {
+	return value.EncodeNested(writer)
 }
 
-func (c *codeForStruct) decodeNested(reader io.Reader, value *StructValue) error {
+// DecodeNested decodes the value from the nested form
+func (value *StructValue) DecodeNested(reader io.Reader) error {
 	for _, field := range value.Fields {
-		err := c.generalCodec.doDecodeNested(reader, field.Value)
+		err := field.Value.DecodeNested(reader)
 		if err != nil {
 			return fmt.Errorf("cannot decode field '%s' of struct, because of: %w", field.Name, err)
 		}
@@ -36,7 +40,8 @@ func (c *codeForStruct) decodeNested(reader io.Reader, value *StructValue) error
 	return nil
 }
 
-func (c *codeForStruct) decodeTopLevel(data []byte, value *StructValue) error {
+// DecodeTopLevel decodes the value from the top-level form
+func (value *StructValue) DecodeTopLevel(data []byte) error {
 	reader := bytes.NewReader(data)
-	return c.decodeNested(reader, value)
+	return value.DecodeNested(reader)
 }

--- a/abi/structValue_test.go
+++ b/abi/structValue_test.go
@@ -4,20 +4,18 @@ import (
 	"testing"
 )
 
-func TestCodecForStruct(t *testing.T) {
-	codec, _ := newCodec(argsNewCodec{
-		pubKeyLength: 32,
-	})
+func TestStructValue(t *testing.T) {
+	codec := &codec{}
 
 	t.Run("should encode nested", func(t *testing.T) {
 		testEncodeNested(t, codec,
-			StructValue{
+			&StructValue{
 				Fields: []Field{
 					{
-						Value: U8Value{Value: 0x01},
+						Value: &U8Value{Value: 0x01},
 					},
 					{
-						Value: U16Value{Value: 0x4142},
+						Value: &U16Value{Value: 0x4142},
 					},
 				},
 			},
@@ -27,13 +25,13 @@ func TestCodecForStruct(t *testing.T) {
 
 	t.Run("should encode top-level", func(t *testing.T) {
 		testEncodeTopLevel(t, codec,
-			StructValue{
+			&StructValue{
 				Fields: []Field{
 					{
-						Value: U8Value{Value: 0x01},
+						Value: &U8Value{Value: 0x01},
 					},
 					{
-						Value: U16Value{Value: 0x4142},
+						Value: &U16Value{Value: 0x4142},
 					},
 				},
 			},


### PR DESCRIPTION
This is a PR from a series of many.

Here, we rewrite some of the codecs into objects that implement the `SingleValue` interface:
 - `codecForAddress` becomes `AddressValue`
 - `codecForBool` becomes `BoolValue`
 - etc.

Some codecs were left for future PRs (some of them have a slightly more complex transition).

See: https://github.com/multiversx/mx-sdk-abi-go/issues/5.