### PR TITLE
Refactor small int values

### DIFF
--- a/abi/smallIntValues.go
+++ b/abi/smallIntValues.go
@@ -5,15 +5,261 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math"
 	"math/big"
 
 	twos "github.com/multiversx/mx-components-big-int/twos-complement"
 )
 
-type codecForSmallInt struct {
+// U8Value is a wrapper for uint8
+type U8Value struct {
+	Value uint8
 }
 
-func (c *codecForSmallInt) encodeNested(writer io.Writer, value any, numBytes int) error {
+// EncodeNested encodes the value in the nested form
+func (value *U8Value) EncodeNested(writer io.Writer) error {
+	return encodeNestedSmallInt(writer, value.Value, 1)
+}
+
+// EncodeTopLevel encodes the value in the top-level form
+func (value *U8Value) EncodeTopLevel(writer io.Writer) error {
+	return encodeTopLevelUnsignedSmallInt(writer, uint64(value.Value))
+}
+
+// DecodeNested decodes the value from the nested form
+func (value *U8Value) DecodeNested(reader io.Reader) error {
+	return decodeNestedSmallInt(reader, &value.Value, 1)
+}
+
+// DecodeTopLevel decodes the value from the top-level form
+func (value *U8Value) DecodeTopLevel(data []byte) error {
+	decoded, err := decodeTopLevelUnsignedSmallInt(data, math.MaxUint8)
+	if err != nil {
+		return err
+	}
+
+	value.Value = uint8(decoded)
+	return nil
+}
+
+// U16Value is a wrapper for uint16
+type U16Value struct {
+	Value uint16
+}
+
+// EncodeNested encodes the value in the nested form
+func (value *U16Value) EncodeNested(writer io.Writer) error {
+	return encodeNestedSmallInt(writer, value.Value, 2)
+}
+
+// EncodeTopLevel encodes the value in the top-level form
+func (value *U16Value) EncodeTopLevel(writer io.Writer) error {
+	return encodeTopLevelUnsignedSmallInt(writer, uint64(value.Value))
+}
+
+// DecodeNested decodes the value from the nested form
+func (value *U16Value) DecodeNested(reader io.Reader) error {
+	return decodeNestedSmallInt(reader, &value.Value, 2)
+}
+
+// DecodeTopLevel decodes the value from the top-level form
+func (value *U16Value) DecodeTopLevel(data []byte) error {
+	decoded, err := decodeTopLevelUnsignedSmallInt(data, math.MaxUint16)
+	if err != nil {
+		return err
+	}
+
+	value.Value = uint16(decoded)
+	return nil
+}
+
+// U32Value is a wrapper for uint16
+type U32Value struct {
+	Value uint32
+}
+
+// EncodeNested encodes the value in the nested form
+func (value *U32Value) EncodeNested(writer io.Writer) error {
+	return encodeNestedSmallInt(writer, value.Value, 4)
+}
+
+// EncodeTopLevel encodes the value in the top-level form
+func (value *U32Value) EncodeTopLevel(writer io.Writer) error {
+	return encodeTopLevelUnsignedSmallInt(writer, uint64(value.Value))
+}
+
+// DecodeNested decodes the value from the nested form
+func (value *U32Value) DecodeNested(reader io.Reader) error {
+	return decodeNestedSmallInt(reader, &value.Value, 4)
+}
+
+// DecodeTopLevel decodes the value from the top-level form
+func (value *U32Value) DecodeTopLevel(data []byte) error {
+	decoded, err := decodeTopLevelUnsignedSmallInt(data, math.MaxUint32)
+	if err != nil {
+		return err
+	}
+
+	value.Value = uint32(decoded)
+	return nil
+}
+
+// U64Value is a wrapper for uint16
+type U64Value struct {
+	Value uint64
+}
+
+// EncodeNested encodes the value in the nested form
+func (value *U64Value) EncodeNested(writer io.Writer) error {
+	return encodeNestedSmallInt(writer, value.Value, 8)
+}
+
+// EncodeTopLevel encodes the value in the top-level form
+func (value *U64Value) EncodeTopLevel(writer io.Writer) error {
+	return encodeTopLevelUnsignedSmallInt(writer, uint64(value.Value))
+}
+
+// DecodeNested decodes the value from the nested form
+func (value *U64Value) DecodeNested(reader io.Reader) error {
+	return decodeNestedSmallInt(reader, &value.Value, 8)
+}
+
+// DecodeTopLevel decodes the value from the top-level form
+func (value *U64Value) DecodeTopLevel(data []byte) error {
+	decoded, err := decodeTopLevelUnsignedSmallInt(data, math.MaxUint64)
+	if err != nil {
+		return err
+	}
+
+	value.Value = uint64(decoded)
+	return nil
+}
+
+// I8Value is a wrapper for uint8
+type I8Value struct {
+	Value int8
+}
+
+// EncodeNested encodes the value in the nested form
+func (value *I8Value) EncodeNested(writer io.Writer) error {
+	return encodeNestedSmallInt(writer, value.Value, 1)
+}
+
+// EncodeTopLevel encodes the value in the top-level form
+func (value *I8Value) EncodeTopLevel(writer io.Writer) error {
+	return encodeTopLevelSignedSmallInt(writer, int64(value.Value))
+}
+
+// DecodeNested decodes the value from the nested form
+func (value *I8Value) DecodeNested(reader io.Reader) error {
+	return decodeNestedSmallInt(reader, &value.Value, 1)
+}
+
+// DecodeTopLevel decodes the value from the top-level form
+func (value *I8Value) DecodeTopLevel(data []byte) error {
+	decoded, err := decodeTopLevelSignedSmallInt(data, math.MaxInt8)
+	if err != nil {
+		return err
+	}
+
+	value.Value = int8(decoded)
+	return nil
+}
+
+// I16Value is a wrapper for uint16
+type I16Value struct {
+	Value int16
+}
+
+// EncodeNested encodes the value in the nested form
+func (value *I16Value) EncodeNested(writer io.Writer) error {
+	return encodeNestedSmallInt(writer, value.Value, 2)
+}
+
+// EncodeTopLevel encodes the value in the top-level form
+func (value *I16Value) EncodeTopLevel(writer io.Writer) error {
+	return encodeTopLevelSignedSmallInt(writer, int64(value.Value))
+}
+
+// DecodeNested decodes the value from the nested form
+func (value *I16Value) DecodeNested(reader io.Reader) error {
+	return decodeNestedSmallInt(reader, &value.Value, 2)
+}
+
+// DecodeTopLevel decodes the value from the top-level form
+func (value *I16Value) DecodeTopLevel(data []byte) error {
+	decoded, err := decodeTopLevelSignedSmallInt(data, math.MaxInt16)
+	if err != nil {
+		return err
+	}
+
+	value.Value = int16(decoded)
+	return nil
+}
+
+// I32Value is a wrapper for uint16
+type I32Value struct {
+	Value int32
+}
+
+// EncodeNested encodes the value in the nested form
+func (value *I32Value) EncodeNested(writer io.Writer) error {
+	return encodeNestedSmallInt(writer, value.Value, 4)
+}
+
+// EncodeTopLevel encodes the value in the top-level form
+func (value *I32Value) EncodeTopLevel(writer io.Writer) error {
+	return encodeTopLevelSignedSmallInt(writer, int64(value.Value))
+}
+
+// DecodeNested decodes the value from the nested form
+func (value *I32Value) DecodeNested(reader io.Reader) error {
+	return decodeNestedSmallInt(reader, &value.Value, 4)
+}
+
+// DecodeTopLevel decodes the value from the top-level form
+func (value *I32Value) DecodeTopLevel(data []byte) error {
+	decoded, err := decodeTopLevelSignedSmallInt(data, math.MaxInt32)
+	if err != nil {
+		return err
+	}
+
+	value.Value = int32(decoded)
+	return nil
+}
+
+// I64Value is a wrapper for uint16
+type I64Value struct {
+	Value int64
+}
+
+// EncodeNested encodes the value in the nested form
+func (value *I64Value) EncodeNested(writer io.Writer) error {
+	return encodeNestedSmallInt(writer, value.Value, 8)
+}
+
+// EncodeTopLevel encodes the value in the top-level form
+func (value *I64Value) EncodeTopLevel(writer io.Writer) error {
+	return encodeTopLevelSignedSmallInt(writer, int64(value.Value))
+}
+
+// DecodeNested decodes the value from the nested form
+func (value *I64Value) DecodeNested(reader io.Reader) error {
+	return decodeNestedSmallInt(reader, &value.Value, 8)
+}
+
+// DecodeTopLevel decodes the value from the top-level form
+func (value *I64Value) DecodeTopLevel(data []byte) error {
+	decoded, err := decodeTopLevelSignedSmallInt(data, math.MaxInt64)
+	if err != nil {
+		return err
+	}
+
+	value.Value = int64(decoded)
+	return nil
+}
+
+func encodeNestedSmallInt(writer io.Writer, value any, numBytes int) error {
 	buffer := new(bytes.Buffer)
 
 	err := binary.Write(buffer, binary.BigEndian, value)
@@ -34,20 +280,20 @@ func (c *codecForSmallInt) encodeNested(writer io.Writer, value any, numBytes in
 	return nil
 }
 
-func (c *codecForSmallInt) encodeTopLevelUnsigned(writer io.Writer, value uint64) error {
+func encodeTopLevelUnsignedSmallInt(writer io.Writer, value uint64) error {
 	b := big.NewInt(0).SetUint64(value)
 	data := b.Bytes()
 	_, err := writer.Write(data)
 	return err
 }
 
-func (c *codecForSmallInt) encodeTopLevelSigned(writer io.Writer, value int64) error {
+func encodeTopLevelSignedSmallInt(writer io.Writer, value int64) error {
 	data := twos.ToBytes(big.NewInt(value))
 	_, err := writer.Write(data)
 	return err
 }
 
-func (c *codecForSmallInt) decodeNested(reader io.Reader, value any, numBytes int) error {
+func decodeNestedSmallInt(reader io.Reader, value any, numBytes int) error {
 	data, err := readBytesExactly(reader, numBytes)
 	if err != nil {
 		return err
@@ -62,7 +308,7 @@ func (c *codecForSmallInt) decodeNested(reader io.Reader, value any, numBytes in
 	return nil
 }
 
-func (c *codecForSmallInt) decodeTopLevelUnsigned(data []byte, maxValue uint64) (uint64, error) {
+func decodeTopLevelUnsignedSmallInt(data []byte, maxValue uint64) (uint64, error) {
 	b := big.NewInt(0).SetBytes(data)
 	if !b.IsUint64() {
 		return 0, fmt.Errorf("decoded value is too large or invalid: %s", b)
@@ -76,7 +322,7 @@ func (c *codecForSmallInt) decodeTopLevelUnsigned(data []byte, maxValue uint64) 
 	return n, nil
 }
 
-func (c *codecForSmallInt) decodeTopLevelSigned(data []byte, maxValue int64) (int64, error) {
+func decodeTopLevelSignedSmallInt(data []byte, maxValue int64) (int64, error) {
 	b := twos.FromBytes(data)
 
 	if !b.IsInt64() {

--- a/abi/smallIntValues_test.go
+++ b/abi/smallIntValues_test.go
@@ -4,82 +4,80 @@ import (
 	"testing"
 )
 
-func TestCodecForSmallInt(t *testing.T) {
-	codec, _ := newCodec(argsNewCodec{
-		pubKeyLength: 32,
-	})
+func TestSmallIntValues(t *testing.T) {
+	codec := &codec{}
 
 	t.Run("should encode nested", func(t *testing.T) {
-		testEncodeNested(t, codec, U8Value{Value: 0x00}, "00")
-		testEncodeNested(t, codec, U8Value{Value: 0x01}, "01")
-		testEncodeNested(t, codec, U8Value{Value: 0x42}, "42")
-		testEncodeNested(t, codec, U8Value{Value: 0xff}, "ff")
+		testEncodeNested(t, codec, &U8Value{Value: 0x00}, "00")
+		testEncodeNested(t, codec, &U8Value{Value: 0x01}, "01")
+		testEncodeNested(t, codec, &U8Value{Value: 0x42}, "42")
+		testEncodeNested(t, codec, &U8Value{Value: 0xff}, "ff")
 
-		testEncodeNested(t, codec, I8Value{Value: 0x00}, "00")
-		testEncodeNested(t, codec, I8Value{Value: 0x01}, "01")
-		testEncodeNested(t, codec, I8Value{Value: -1}, "ff")
-		testEncodeNested(t, codec, I8Value{Value: -128}, "80")
-		testEncodeNested(t, codec, I8Value{Value: 127}, "7f")
+		testEncodeNested(t, codec, &I8Value{Value: 0x00}, "00")
+		testEncodeNested(t, codec, &I8Value{Value: 0x01}, "01")
+		testEncodeNested(t, codec, &I8Value{Value: -1}, "ff")
+		testEncodeNested(t, codec, &I8Value{Value: -128}, "80")
+		testEncodeNested(t, codec, &I8Value{Value: 127}, "7f")
 
-		testEncodeNested(t, codec, U16Value{Value: 0x0000}, "0000")
-		testEncodeNested(t, codec, U16Value{Value: 0x0011}, "0011")
-		testEncodeNested(t, codec, U16Value{Value: 0x1234}, "1234")
-		testEncodeNested(t, codec, U16Value{Value: 0xffff}, "ffff")
+		testEncodeNested(t, codec, &U16Value{Value: 0x0000}, "0000")
+		testEncodeNested(t, codec, &U16Value{Value: 0x0011}, "0011")
+		testEncodeNested(t, codec, &U16Value{Value: 0x1234}, "1234")
+		testEncodeNested(t, codec, &U16Value{Value: 0xffff}, "ffff")
 
-		testEncodeNested(t, codec, I16Value{Value: 0x0000}, "0000")
-		testEncodeNested(t, codec, I16Value{Value: 0x0011}, "0011")
-		testEncodeNested(t, codec, I16Value{Value: -1}, "ffff")
-		testEncodeNested(t, codec, I16Value{Value: -32768}, "8000")
+		testEncodeNested(t, codec, &I16Value{Value: 0x0000}, "0000")
+		testEncodeNested(t, codec, &I16Value{Value: 0x0011}, "0011")
+		testEncodeNested(t, codec, &I16Value{Value: -1}, "ffff")
+		testEncodeNested(t, codec, &I16Value{Value: -32768}, "8000")
 
-		testEncodeNested(t, codec, U32Value{Value: 0x00000000}, "00000000")
-		testEncodeNested(t, codec, U32Value{Value: 0x00000011}, "00000011")
-		testEncodeNested(t, codec, U32Value{Value: 0x00001122}, "00001122")
-		testEncodeNested(t, codec, U32Value{Value: 0x00112233}, "00112233")
-		testEncodeNested(t, codec, U32Value{Value: 0x11223344}, "11223344")
-		testEncodeNested(t, codec, U32Value{Value: 0xffffffff}, "ffffffff")
+		testEncodeNested(t, codec, &U32Value{Value: 0x00000000}, "00000000")
+		testEncodeNested(t, codec, &U32Value{Value: 0x00000011}, "00000011")
+		testEncodeNested(t, codec, &U32Value{Value: 0x00001122}, "00001122")
+		testEncodeNested(t, codec, &U32Value{Value: 0x00112233}, "00112233")
+		testEncodeNested(t, codec, &U32Value{Value: 0x11223344}, "11223344")
+		testEncodeNested(t, codec, &U32Value{Value: 0xffffffff}, "ffffffff")
 
-		testEncodeNested(t, codec, I32Value{Value: 0x00000000}, "00000000")
-		testEncodeNested(t, codec, I32Value{Value: 0x00000011}, "00000011")
-		testEncodeNested(t, codec, I32Value{Value: -1}, "ffffffff")
-		testEncodeNested(t, codec, I32Value{Value: -2147483648}, "80000000")
+		testEncodeNested(t, codec, &I32Value{Value: 0x00000000}, "00000000")
+		testEncodeNested(t, codec, &I32Value{Value: 0x00000011}, "00000011")
+		testEncodeNested(t, codec, &I32Value{Value: -1}, "ffffffff")
+		testEncodeNested(t, codec, &I32Value{Value: -2147483648}, "80000000")
 
-		testEncodeNested(t, codec, U64Value{Value: 0x0000000000000000}, "0000000000000000")
-		testEncodeNested(t, codec, U64Value{Value: 0x0000000000000011}, "0000000000000011")
-		testEncodeNested(t, codec, U64Value{Value: 0x0011223344556677}, "0011223344556677")
-		testEncodeNested(t, codec, U64Value{Value: 0xffffffffffffffff}, "ffffffffffffffff")
+		testEncodeNested(t, codec, &U64Value{Value: 0x0000000000000000}, "0000000000000000")
+		testEncodeNested(t, codec, &U64Value{Value: 0x0000000000000011}, "0000000000000011")
+		testEncodeNested(t, codec, &U64Value{Value: 0x0011223344556677}, "0011223344556677")
+		testEncodeNested(t, codec, &U64Value{Value: 0xffffffffffffffff}, "ffffffffffffffff")
 
-		testEncodeNested(t, codec, I64Value{Value: 0x0000000000000000}, "0000000000000000")
-		testEncodeNested(t, codec, I64Value{Value: 0x0000000000000011}, "0000000000000011")
-		testEncodeNested(t, codec, I64Value{Value: -1}, "ffffffffffffffff")
-		testEncodeNested(t, codec, I64Value{Value: -9223372036854775808}, "8000000000000000")
+		testEncodeNested(t, codec, &I64Value{Value: 0x0000000000000000}, "0000000000000000")
+		testEncodeNested(t, codec, &I64Value{Value: 0x0000000000000011}, "0000000000000011")
+		testEncodeNested(t, codec, &I64Value{Value: -1}, "ffffffffffffffff")
+		testEncodeNested(t, codec, &I64Value{Value: -9223372036854775808}, "8000000000000000")
 	})
 
 	t.Run("should encode top-level", func(t *testing.T) {
-		testEncodeTopLevel(t, codec, U8Value{Value: 0x00}, "")
-		testEncodeTopLevel(t, codec, U8Value{Value: 0x01}, "01")
+		testEncodeTopLevel(t, codec, &U8Value{Value: 0x00}, "")
+		testEncodeTopLevel(t, codec, &U8Value{Value: 0x01}, "01")
 
-		testEncodeTopLevel(t, codec, I8Value{Value: 0x00}, "")
-		testEncodeTopLevel(t, codec, I8Value{Value: 0x01}, "01")
-		testEncodeTopLevel(t, codec, I8Value{Value: -1}, "ff")
+		testEncodeTopLevel(t, codec, &I8Value{Value: 0x00}, "")
+		testEncodeTopLevel(t, codec, &I8Value{Value: 0x01}, "01")
+		testEncodeTopLevel(t, codec, &I8Value{Value: -1}, "ff")
 
-		testEncodeTopLevel(t, codec, U16Value{Value: 0x0000}, "")
-		testEncodeTopLevel(t, codec, U16Value{Value: 0x0011}, "11")
+		testEncodeTopLevel(t, codec, &U16Value{Value: 0x0000}, "")
+		testEncodeTopLevel(t, codec, &U16Value{Value: 0x0011}, "11")
 
-		testEncodeTopLevel(t, codec, I16Value{Value: 0x0000}, "")
-		testEncodeTopLevel(t, codec, I16Value{Value: 0x0011}, "11")
-		testEncodeTopLevel(t, codec, I16Value{Value: -1}, "ff")
+		testEncodeTopLevel(t, codec, &I16Value{Value: 0x0000}, "")
+		testEncodeTopLevel(t, codec, &I16Value{Value: 0x0011}, "11")
+		testEncodeTopLevel(t, codec, &I16Value{Value: -1}, "ff")
 
-		testEncodeTopLevel(t, codec, U32Value{Value: 0x00004242}, "4242")
+		testEncodeTopLevel(t, codec, &U32Value{Value: 0x00004242}, "4242")
 
-		testEncodeTopLevel(t, codec, I32Value{Value: 0x00000000}, "")
-		testEncodeTopLevel(t, codec, I32Value{Value: 0x00000011}, "11")
-		testEncodeTopLevel(t, codec, I32Value{Value: -1}, "ff")
+		testEncodeTopLevel(t, codec, &I32Value{Value: 0x00000000}, "")
+		testEncodeTopLevel(t, codec, &I32Value{Value: 0x00000011}, "11")
+		testEncodeTopLevel(t, codec, &I32Value{Value: -1}, "ff")
 
-		testEncodeTopLevel(t, codec, U64Value{Value: 0x0042434445464748}, "42434445464748")
+		testEncodeTopLevel(t, codec, &U64Value{Value: 0x0042434445464748}, "42434445464748")
 
-		testEncodeTopLevel(t, codec, I64Value{Value: 0x0000000000000000}, "")
-		testEncodeTopLevel(t, codec, I64Value{Value: 0x0000000000000011}, "11")
-		testEncodeTopLevel(t, codec, I64Value{Value: -1}, "ff")
+		testEncodeTopLevel(t, codec, &I64Value{Value: 0x0000000000000000}, "")
+		testEncodeTopLevel(t, codec, &I64Value{Value: 0x0000000000000011}, "11")
+		testEncodeTopLevel(t, codec, &I64Value{Value: -1}, "ff")
 	})
 
 	t.Run("should decode nested", func(t *testing.T) {


### PR DESCRIPTION
This is a PR from a series of many.

Here we refactor the small int values - now, the implement the `SingleValue` interface, as well.

See: https://github.com/multiversx/mx-sdk-abi-go/issues/5.