### PR TITLE
Refactoring: lists and options

### DIFF
--- a/abi/listValue.go
+++ b/abi/listValue.go
@@ -27,7 +27,6 @@ func (value *ListValue) EncodeTopLevel(writer io.Writer) error {
 	return value.encodeItems(writer)
 }
 
-// DecodeNested decodes the value from the nested form
 func (value *ListValue) encodeItems(writer io.Writer) error {
 	for _, item := range value.Items {
 		err := item.EncodeNested(writer)

--- a/abi/listValue_test.go
+++ b/abi/listValue_test.go
@@ -7,18 +7,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCodecForList(t *testing.T) {
-	codec, _ := newCodec(argsNewCodec{
-		pubKeyLength: 32,
-	})
+func TestListValue(t *testing.T) {
+	codec := &codec{}
 
 	t.Run("should encode nested", func(t *testing.T) {
 		testEncodeNested(t, codec,
-			InputListValue{
-				Items: []any{
-					U16Value{Value: 1},
-					U16Value{Value: 2},
-					U16Value{Value: 3},
+			&ListValue{
+				Items: []SingleValue{
+					&U16Value{Value: 1},
+					&U16Value{Value: 2},
+					&U16Value{Value: 3},
 				},
 			},
 			"00000003000100020003",
@@ -27,11 +25,11 @@ func TestCodecForList(t *testing.T) {
 
 	t.Run("should encode top-level", func(t *testing.T) {
 		testEncodeTopLevel(t, codec,
-			InputListValue{
-				Items: []any{
-					U16Value{Value: 1},
-					U16Value{Value: 2},
-					U16Value{Value: 3},
+			&ListValue{
+				Items: []SingleValue{
+					&U16Value{Value: 1},
+					&U16Value{Value: 2},
+					&U16Value{Value: 3},
 				},
 			},
 			"000100020003",
@@ -41,15 +39,15 @@ func TestCodecForList(t *testing.T) {
 	t.Run("should decode nested", func(t *testing.T) {
 		data, _ := hex.DecodeString("00000003000100020003")
 
-		destination := &OutputListValue{
-			ItemCreator: func() any { return &U16Value{} },
-			Items:       []any{},
+		destination := &ListValue{
+			ItemCreator: func() SingleValue { return &U16Value{} },
+			Items:       []SingleValue{},
 		}
 
 		err := codec.DecodeNested(data, destination)
 		require.NoError(t, err)
 		require.Equal(t,
-			[]any{
+			[]SingleValue{
 				&U16Value{Value: 1},
 				&U16Value{Value: 2},
 				&U16Value{Value: 3},
@@ -61,15 +59,15 @@ func TestCodecForList(t *testing.T) {
 	t.Run("should decode top-level", func(t *testing.T) {
 		data, _ := hex.DecodeString("000100020003")
 
-		destination := &OutputListValue{
-			ItemCreator: func() any { return &U16Value{} },
-			Items:       []any{},
+		destination := &ListValue{
+			ItemCreator: func() SingleValue { return &U16Value{} },
+			Items:       []SingleValue{},
 		}
 
 		err := codec.DecodeTopLevel(data, destination)
 		require.NoError(t, err)
 		require.Equal(t,
-			[]any{
+			[]SingleValue{
 				&U16Value{Value: 1},
 				&U16Value{Value: 2},
 				&U16Value{Value: 3},

--- a/abi/optionValue_test.go
+++ b/abi/optionValue_test.go
@@ -5,33 +5,33 @@ import (
 )
 
 func TestCodecForOption(t *testing.T) {
-	codec, _ := newCodec(argsNewCodec{
-		pubKeyLength: 32,
-	})
+	codec := &codec{}
 
 	t.Run("should encode nested", func(t *testing.T) {
-		testEncodeNested(t, codec, OptionValue{
+		testEncodeNested(t, codec, &OptionValue{
 			Value: nil,
 		}, "00")
 
-		testEncodeNested(t, codec, OptionValue{
-			Value: U16Value{Value: 0x08},
+		testEncodeNested(t, codec, &OptionValue{
+			Value: &U16Value{Value: 0x08},
 		}, "010008")
 	})
 
 	t.Run("should encode top-level", func(t *testing.T) {
-		testEncodeTopLevel(t, codec, OptionValue{
+		testEncodeTopLevel(t, codec, &OptionValue{
 			Value: nil,
 		}, "")
 
-		testEncodeTopLevel(t, codec, OptionValue{
-			Value: U16Value{Value: 0x08},
+		testEncodeTopLevel(t, codec, &OptionValue{
+			Value: &U16Value{Value: 0x08},
 		}, "010008")
 	})
 
 	t.Run("should decode nested", func(t *testing.T) {
 		testDecodeNested(t, codec, "00",
-			&OptionValue{},
+			&OptionValue{
+				Value: &U8Value{},
+			},
 			&OptionValue{
 				Value: nil,
 			},
@@ -47,13 +47,19 @@ func TestCodecForOption(t *testing.T) {
 		)
 	})
 
+	t.Run("should err on decode nested (nil placeholder)", func(t *testing.T) {
+		testDecodeNestedWithError(t, codec, "072a", &OptionValue{}, "placeholder value of option should be set before decoding")
+	})
+
 	t.Run("should err on decode nested (bad marker for value presence)", func(t *testing.T) {
-		testDecodeNestedWithError(t, codec, "072a", &OptionValue{}, "invalid first byte for nested encoded option: 7")
+		testDecodeNestedWithError(t, codec, "072a", &OptionValue{Value: &BytesValue{}}, "invalid first byte for nested encoded option: 7")
 	})
 
 	t.Run("should decode top-level", func(t *testing.T) {
 		testDecodeTopLevel(t, codec, "",
-			&OptionValue{},
+			&OptionValue{
+				Value: &U8Value{},
+			},
 			&OptionValue{
 				Value: nil,
 			},
@@ -69,8 +75,12 @@ func TestCodecForOption(t *testing.T) {
 		)
 	})
 
+	t.Run("should err on decode top-level (nil placeholder)", func(t *testing.T) {
+		testDecodeTopLevelWithError(t, codec, "072a", &OptionValue{}, "placeholder value of option should be set before decoding")
+	})
+
 	t.Run("should err on decode top-level (bad marker for value presence)", func(t *testing.T) {
-		testDecodeTopLevelWithError(t, codec, "002a", &OptionValue{}, "invalid first byte for top-level encoded option: 0")
-		testDecodeTopLevelWithError(t, codec, "072a", &OptionValue{}, "invalid first byte for top-level encoded option: 7")
+		testDecodeTopLevelWithError(t, codec, "002a", &OptionValue{Value: &BytesValue{}}, "invalid first byte for top-level encoded option: 0")
+		testDecodeTopLevelWithError(t, codec, "072a", &OptionValue{Value: &BytesValue{}}, "invalid first byte for top-level encoded option: 7")
 	})
 }


### PR DESCRIPTION
This is a PR from a series of many.

 - `ListValue` becomes a `SingleValue`, as well (the same as the others). Additionally, `InputListValue` and `OutputListValue` are merged.
 - `OptionValue` becomes a `SingleValue`, as well. Additional check (placeholder is required for decoding).

See: https://github.com/multiversx/mx-sdk-abi-go/issues/5.