### PR TITLE
Refactor enums. Add "fields provider" for heterogeneous enums

### DIFF
--- a/abi/enumValue_test.go
+++ b/abi/enumValue_test.go
@@ -1,38 +1,39 @@
 package abi
 
 import (
+	"encoding/hex"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-func TestCodecForEnum(t *testing.T) {
-	codec, _ := newCodec(argsNewCodec{
-		pubKeyLength: 32,
-	})
+func TestEnumValue(t *testing.T) {
+	codec := &codec{}
 
 	t.Run("should encode nested", func(t *testing.T) {
 		testEncodeNested(t, codec,
-			EnumValue{
+			&EnumValue{
 				Discriminant: 0,
 			},
 			"00",
 		)
 
 		testEncodeNested(t, codec,
-			EnumValue{
+			&EnumValue{
 				Discriminant: 42,
 			},
 			"2a",
 		)
 
 		testEncodeNested(t, codec,
-			EnumValue{
+			&EnumValue{
 				Discriminant: 42,
 				Fields: []Field{
 					{
-						Value: U8Value{Value: 0x01},
+						Value: &U8Value{Value: 0x01},
 					},
 					{
-						Value: U16Value{Value: 0x4142},
+						Value: &U16Value{Value: 0x4142},
 					},
 				},
 			},
@@ -42,28 +43,28 @@ func TestCodecForEnum(t *testing.T) {
 
 	t.Run("should encode top-level", func(t *testing.T) {
 		testEncodeTopLevel(t, codec,
-			EnumValue{
+			&EnumValue{
 				Discriminant: 0,
 			},
 			"",
 		)
 
 		testEncodeTopLevel(t, codec,
-			EnumValue{
+			&EnumValue{
 				Discriminant: 42,
 			},
 			"2a",
 		)
 
 		testEncodeTopLevel(t, codec,
-			EnumValue{
+			&EnumValue{
 				Discriminant: 42,
 				Fields: []Field{
 					{
-						Value: U8Value{Value: 0x01},
+						Value: &U8Value{Value: 0x01},
 					},
 					{
-						Value: U16Value{Value: 0x4142},
+						Value: &U16Value{Value: 0x4142},
 					},
 				},
 			},
@@ -71,89 +72,127 @@ func TestCodecForEnum(t *testing.T) {
 		)
 	})
 
-	t.Run("should decode nested", func(t *testing.T) {
-		testDecodeNested(t, codec,
-			"00",
-			&EnumValue{},
-			&EnumValue{
-				Discriminant: 0x00,
-			},
-		)
+	t.Run("should decode nested (simple)", func(t *testing.T) {
+		data, _ := hex.DecodeString("2a")
 
-		testDecodeNested(t, codec,
-			"2a",
-			&EnumValue{},
-			&EnumValue{
-				Discriminant: 42,
+		destination := &EnumValue{
+			FieldsProvider: func(discriminant uint8) []Field {
+				return nil
 			},
-		)
+		}
 
-		testDecodeNested(t, codec,
-			"01014142",
-			&EnumValue{
-				Fields: []Field{
+		err := codec.DecodeNested(data, destination)
+		require.NoError(t, err)
+		require.Equal(t, uint8(42), destination.Discriminant)
+		require.Empty(t, destination.Fields)
+	})
+
+	t.Run("should decode nested (simple, zero)", func(t *testing.T) {
+		data, _ := hex.DecodeString("00")
+
+		destination := &EnumValue{
+			FieldsProvider: func(discriminant uint8) []Field {
+				return nil
+			},
+		}
+
+		err := codec.DecodeNested(data, destination)
+		require.NoError(t, err)
+		require.Equal(t, uint8(0), destination.Discriminant)
+		require.Empty(t, destination.Fields)
+	})
+
+	t.Run("should decode nested (heterogeneous)", func(t *testing.T) {
+		data, _ := hex.DecodeString("01014142")
+
+		destination := &EnumValue{
+			FieldsProvider: func(discriminant uint8) []Field {
+				return []Field{
 					{
 						Value: &U8Value{},
 					},
 					{
 						Value: &U16Value{},
 					},
+				}
+			},
+		}
+
+		err := codec.DecodeNested(data, destination)
+		require.NoError(t, err)
+		require.Equal(t, uint8(1), destination.Discriminant)
+		require.Equal(t,
+			[]Field{
+				{
+					Value: &U8Value{Value: 0x01},
+				},
+				{
+					Value: &U16Value{Value: 0x4142},
 				},
 			},
-			&EnumValue{
-				Discriminant: 0x01,
-				Fields: []Field{
-					{
-						Value: &U8Value{Value: 0x01},
-					},
-					{
-						Value: &U16Value{Value: 0x4142},
-					},
-				},
-			},
+			destination.Fields,
 		)
 	})
 
-	t.Run("should decode top-level", func(t *testing.T) {
-		testDecodeTopLevel(t, codec,
-			"",
-			&EnumValue{},
-			&EnumValue{
-				Discriminant: 0x00,
-			},
-		)
+	t.Run("should decode top-level (simple)", func(t *testing.T) {
+		data, _ := hex.DecodeString("2a")
 
-		testDecodeTopLevel(t, codec,
-			"2a",
-			&EnumValue{},
-			&EnumValue{
-				Discriminant: 42,
+		destination := &EnumValue{
+			FieldsProvider: func(discriminant uint8) []Field {
+				return nil
 			},
-		)
+		}
 
-		testDecodeTopLevel(t, codec,
-			"01014142",
-			&EnumValue{
-				Fields: []Field{
+		err := codec.DecodeTopLevel(data, destination)
+		require.NoError(t, err)
+		require.Equal(t, uint8(42), destination.Discriminant)
+		require.Empty(t, destination.Fields)
+	})
+
+	t.Run("should decode top-level (simple, zero)", func(t *testing.T) {
+		data, _ := hex.DecodeString("")
+
+		destination := &EnumValue{
+			FieldsProvider: func(discriminant uint8) []Field {
+				return nil
+			},
+		}
+
+		err := codec.DecodeTopLevel(data, destination)
+		require.NoError(t, err)
+		require.Equal(t, uint8(0), destination.Discriminant)
+		require.Empty(t, destination.Fields)
+	})
+
+	t.Run("should decode top-level (heterogeneous)", func(t *testing.T) {
+		data, _ := hex.DecodeString("01014142")
+
+		destination := &EnumValue{
+			FieldsProvider: func(discriminant uint8) []Field {
+				return []Field{
 					{
 						Value: &U8Value{},
 					},
 					{
 						Value: &U16Value{},
 					},
+				}
+			},
+		}
+
+		err := codec.DecodeNested(data, destination)
+		require.NoError(t, err)
+		require.Equal(t, uint8(1), destination.Discriminant)
+		require.Equal(t,
+			[]Field{
+				{
+					Value: &U8Value{Value: 0x01},
+				},
+				{
+					Value: &U16Value{Value: 0x4142},
 				},
 			},
-			&EnumValue{
-				Discriminant: 0x01,
-				Fields: []Field{
-					{
-						Value: &U8Value{Value: 0x01},
-					},
-					{
-						Value: &U16Value{Value: 0x4142},
-					},
-				},
-			},
+			destination.Fields,
 		)
 	})
 }

--- a/abi/serializer_test.go
+++ b/abi/serializer_test.go
@@ -551,30 +551,36 @@ func TestSerializer_InRealWorldScenarios(t *testing.T) {
 			},
 		}
 
-		action := EnumValue{
-			Fields: []Field{
-				{
-					Name:  "to",
-					Value: &actionTo,
-				},
-				{
-					Name:  "egld_amount",
-					Value: &actionEgldAmount,
-				},
-				{
-					Name: "opt_gas_limit",
-					Value: &OptionValue{
-						Value: &actionGasLimit,
-					},
-				},
-				{
-					Name:  "endpoint_name",
-					Value: &actionEndpointName,
-				},
-				{
-					Name:  "arguments",
-					Value: &actionArguments,
-				},
+		action := &EnumValue{
+			FieldsProvider: func(discriminant uint8) []Field {
+				if discriminant == 5 {
+					return []Field{
+						{
+							Name:  "to",
+							Value: actionTo,
+						},
+						{
+							Name:  "egld_amount",
+							Value: actionEgldAmount,
+						},
+						{
+							Name: "opt_gas_limit",
+							Value: &OptionValue{
+								Value: actionGasLimit,
+							},
+						},
+						{
+							Name:  "endpoint_name",
+							Value: actionEndpointName,
+						},
+						{
+							Name:  "arguments",
+							Value: actionArguments,
+						},
+					}
+				}
+
+				return nil
 			},
 		}
 


### PR DESCRIPTION
This is a PR from a series of many.

 - `EnumValue` becomes a `SingleValue`, as well (the same as the others).
 - We've introduced a `fieldsProvider` - necessary to return the decoding placeholders for heterogeneous enums.

See: https://github.com/multiversx/mx-sdk-abi-go/issues/5.